### PR TITLE
fixing tests for R 3.6

### DIFF
--- a/tests/testthat/test-I2C2.mCI.R
+++ b/tests/testthat/test-I2C2.mCI.R
@@ -1,5 +1,6 @@
 context("Testing I2C2 mCI")
 
+suppressWarnings(RNGversion("3.5.0"))
 set.seed(20170602)
 id = c(1:10, 10:1)
 visit = rep(1:2, each = 10)


### PR DESCRIPTION
Added `suppressWarnings(RNGversion("3.5.0"))` to fix the tests for R-3.6. See here for CI logs: https://travis-ci.com/adigherman/I2C2/jobs/206098736